### PR TITLE
Common module with utils.py

### DIFF
--- a/common/src/utils.py
+++ b/common/src/utils.py
@@ -1,0 +1,41 @@
+import os.path
+import sys
+from git import Repo
+
+# Path to root project git (if needed)
+ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
+PROJECT_ROOT_GIT_PATH = f'{ROOT_PATH}/.git'
+
+# Log messages to be printed by git_push
+COMMIT_MESSAGE = "Update shared repository\n"
+NO_CHANGES_MESSAGE = "No changes detected\n"
+DEBUGGING_MESSAGE = "Skipping git push because it's disabled for debugging.\n"
+PUSHING_MESSAGE = "Pushing files to shared repository\n"
+PUSH_SUCCESSFUL_MESSAGE = "Push successful\n"
+
+
+# Push shared repository to Git if any files changed
+def git_push(git_repo_path, log=sys.stdout, enable_push=True):
+    """Utility method that pushes any updates to the shared_directory to the git repo.
+
+        Args:
+            git_repo_path: The git repo path where the push should happen.
+            log: Where to print messages. Default is to stdout.
+            enable_push: Boolean. Default to True to enable pushing to git repo. Set to False for testing.
+    """
+    repo = Repo(git_repo_path)
+
+    t = repo.head.commit.tree
+    repo.index.add(["shared_directory"])
+    if repo.git.diff(t):
+        repo.index.commit(COMMIT_MESSAGE)
+        if enable_push:
+            log.write(PUSHING_MESSAGE)
+            repo.git.push('origin', 'master')
+            log.write(PUSH_SUCCESSFUL_MESSAGE)
+        else:
+            log.write(DEBUGGING_MESSAGE)
+    else:
+        log.write(NO_CHANGES_MESSAGE)
+
+    repo.close()

--- a/common/src/utils.py
+++ b/common/src/utils.py
@@ -7,28 +7,28 @@ ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
 PROJECT_ROOT_GIT_PATH = f'{ROOT_PATH}/.git'
 
 # Log messages to be printed by git_push
-COMMIT_MESSAGE = "Update shared repository\n"
 NO_CHANGES_MESSAGE = "No changes detected\n"
-DEBUGGING_MESSAGE = "Skipping git push because it's disabled for debugging.\n"
+DEBUGGING_MESSAGE = "Skipping git push because it's disabled for debugging\n"
 PUSHING_MESSAGE = "Pushing files to shared repository\n"
 PUSH_SUCCESSFUL_MESSAGE = "Push successful\n"
 
 
 # Push shared repository to Git if any files changed
-def git_push(git_repo_path, log=sys.stdout, enable_push=True):
-    """Utility method that pushes any updates to the shared_directory to the git repo.
+def git_push(git_repo_path, commit_message="Update shared repository", enable_push=True, log=sys.stdout):
+    """Utility method that pushes any updates to the shared_directory subdirectory of a git repo.
 
         Args:
             git_repo_path: The git repo path where the push should happen.
-            log: Where to print messages. Default is to stdout.
+            commit_message: A string with the message for committing the changes to the git repo.
             enable_push: Boolean. Default to True to enable pushing to git repo. Set to False for testing.
+            log: Where to print messages. Default is to stdout.
     """
     repo = Repo(git_repo_path)
 
     t = repo.head.commit.tree
     repo.index.add(["shared_directory"])
     if repo.git.diff(t):
-        repo.index.commit(COMMIT_MESSAGE)
+        repo.index.commit(commit_message)
         if enable_push:
             log.write(PUSHING_MESSAGE)
             repo.git.push('origin', 'master')

--- a/common/test/test_utils.py
+++ b/common/test/test_utils.py
@@ -1,0 +1,98 @@
+import unittest
+import sys
+import io
+import tempfile
+import shutil
+import os
+from git import Repo
+sys.path.append('src')
+import utils
+
+
+# TODO: SetUp/TearDown to build tempdir with git project with shared_directory to test writing to
+#   each test gets its own subdirectory which is totally clean and unconnected
+
+class TestUtils(unittest.TestCase):
+
+    # Temporary directory to use during testing
+    temp_root_dir = None
+
+    @classmethod
+    def setUpClass(cls):
+
+        # Make a temporary root directory and shared_directory subdir
+        cls.temp_root_dir = tempfile.mkdtemp()
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove temporary root directory and its subdirectories & files
+        shutil.rmtree(cls.temp_root_dir)
+
+    def test_git_push_no_changes(self):
+
+        # Create a directory for this test
+        test_dir = os.path.join(self.temp_root_dir, 'test_git_push_no_changes')
+        if not os.path.exists(test_dir):
+            os.makedirs(test_dir)
+
+        # Create a shared_directory for files inside this test_dir
+        shared_directory = os.path.join(test_dir, 'shared_directory')
+        if not os.path.exists(shared_directory):
+            os.makedirs(shared_directory)
+
+        # Set up a git repository to use during testing
+        temp_repo = Repo.init(test_dir)
+
+        # Create a dummy file and commit it to start the repo history
+        f = os.path.join(test_dir, "DUMMY")
+        open(f, 'wb').close()
+        temp_repo.index.add([f])
+        temp_repo.index.commit("FOO")
+
+        # Call git_push using the test_dir and have it write to the log
+        log = io.StringIO()
+        utils.git_push(test_dir, log=log, enable_push=False)
+
+        # Close the repo
+        temp_repo.close()
+
+        # TEST: When no uncommited changes have been made to the repo,
+        #       it logs the NO_CHANGES_MESSAGE
+        self.assertEqual(log.getvalue(), utils.NO_CHANGES_MESSAGE)
+
+    def test_git_push_with_changes(self):
+
+        # Create a directory for this test
+        test_dir = os.path.join(self.temp_root_dir, 'test_git_push_with_changes')
+        if not os.path.exists(test_dir):
+            os.makedirs(test_dir)
+
+        # Create a shared_directory for files inside this test_dir
+        shared_directory = os.path.join(test_dir, 'shared_directory')
+        if not os.path.exists(shared_directory):
+            os.makedirs(shared_directory)
+
+        # Set up a git repository to use during testing
+        temp_repo = Repo.init(test_dir)
+
+        # Create a dummy file and commit it to start the repo history
+        f = os.path.join(test_dir, "DUMMY")
+        open(f, 'wb').close()
+        temp_repo.index.add([f])
+        temp_repo.index.commit("FOO")
+
+        # Add a file to the shared_directory WITHOUT committing
+        uncommited_file = os.path.join(shared_directory, "uncommitted_file")
+        open(uncommited_file, 'wb').close()
+        temp_repo.index.add([uncommited_file])
+
+        # Call git_push using the test_dir and have it write to the log
+        log = io.StringIO()
+        utils.git_push(test_dir, log=log, enable_push=False)
+
+        # Close the repo
+        temp_repo.close()
+
+        # TEST: When uncommited changes have been made to the repo,
+        #       it logs the DEBUGGING_MESSAGE
+        self.assertEqual(log.getvalue(), utils.DEBUGGING_MESSAGE)

--- a/common/test/test_utils.py
+++ b/common/test/test_utils.py
@@ -1,16 +1,13 @@
-import unittest
-import sys
 import io
-import tempfile
-import shutil
 import os
+import shutil
+import sys
+import tempfile
+import unittest
 from git import Repo
 sys.path.append('src')
 import utils
 
-
-# TODO: SetUp/TearDown to build tempdir with git project with shared_directory to test writing to
-#   each test gets its own subdirectory which is totally clean and unconnected
 
 class TestUtils(unittest.TestCase):
 


### PR DESCRIPTION
Added a new module for common code, including a `utils.py` file. This currently has only `git_push()`, but as we need to, we can add more methods.

For `git_push()`, I used @liquidsteves's version as a base and made a few modifications so that it can be tested. Importantly, I changed the args so that it requires you give it the git repo location to push to (although I did include the project root as a constant which can be accessed via `utils.PROJECT_ROOT_GIT_PATH`).

Note that for the unittests, I wasn't able to write a test case for actually pushing to origin (I tried to set up two repos in the test to do so, but wasn't able to get that to work using gitpython). I did get tests done for no uncommitted changes as well as uncommitted changes where `enable_push=False`.

We should refactor the ingestion code to use this version of `git_push()` once it's merged with master.