### PR TITLE
Removes whitespace from .env.template

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,13 +1,10 @@
 GIT_SSH_COMMAND='ssh -i /var/.ssh_keys/github_deploy_key -o IdentitiesOnly=yes -o StrictHostKeyChecking=no'
-
-TMS_PATH = /var/tms
-TMS_DATA_PATH = /var/tms-data
-
-TMS_DATA_BRANCH_NAME = your-branch-name
-TMS_DATA_GIT_REPOSITORY = git@github.com:nyc-cto/tms-data.git
-
-SERGE_TS = ${TMS_PATH}/serge/ts
-TS_SERGE_COPY = ${TMS_DATA_PATH}/po_files/serge_copy
-TS_INBOX = ${TMS_DATA_PATH}/po_files/inbox
-TS_OUTBOX = ${TMS_DATA_PATH}/po_files/outbox
-TRANSLATION_GOOGLE_KEY = ${TMS_PATH}/secrets/TranslationGoogleKey.json
+TMS_PATH=/var/tms
+TMS_DATA_PATH=/var/tms-data
+TMS_DATA_BRANCH_NAME=your-branch-name
+TMS_DATA_GIT_REPOSITORY=git@github.com:nyc-cto/tms-data.git
+SERGE_TS=${TMS_PATH}/serge/ts
+TS_SERGE_COPY=${TMS_DATA_PATH}/po_files/serge_copy
+TS_INBOX=${TMS_DATA_PATH}/po_files/inbox
+TS_OUTBOX=${TMS_DATA_PATH}/po_files/outbox
+TRANSLATION_GOOGLE_KEY=${TMS_PATH}/secrets/TranslationGoogleKey.json


### PR DESCRIPTION
This removes blank lines as well as spaces around the `=` assignment operator. Although it ran fine with whitespace in my environment, Rapi's environment was giving errors for the whitespace, so it is now removed.