### PR TITLE
serge_ts_connector unittests

### DIFF
--- a/serge/configs/base_config.serge
+++ b/serge/configs/base_config.serge
@@ -13,8 +13,8 @@ common-settings
         data
         {
             executable                          python
-            pull_command                        python %ENV:TMS_PATH%/translation_service/src/serge_ts_connector.py --mode pull_ts --serge_dir %ENV:SERGE_TS% --ts_serge_dir %ENV:TS_SERGE_COPY% --ts_inbox %ENV:TS_INBOX% --ts_outbox %ENV:TS_OUTBOX%
-            push_command                        python %ENV:TMS_PATH%/translation_service/src/serge_ts_connector.py --mode push_ts --serge_dir %ENV:SERGE_TS% --ts_serge_dir %ENV:TS_SERGE_COPY% --ts_inbox %ENV:TS_INBOX% --ts_outbox %ENV:TS_OUTBOX%
+            pull_command                        python %ENV:TMS_PATH%/translation_service/src/serge_ts_connector.py --mode pull_ts
+            push_command                        python %ENV:TMS_PATH%/translation_service/src/serge_ts_connector.py --mode push_ts
         }
     }
 

--- a/serge/configs/google_config.serge
+++ b/serge/configs/google_config.serge
@@ -9,7 +9,7 @@ sync
         data
         {
             @inherit                            base_config.serge#common-settings/ts/data
-            push_command                        python %ENV:TMS_PATH%/translation_service/src/serge_ts_connector.py --mode push_ts --serge_dir %ENV:SERGE_TS% --ts_serge_dir %ENV:TS_SERGE_COPY% --ts_inbox %ENV:TS_INBOX% --ts_outbox %ENV:TS_OUTBOX% --translation_api google --google_key_path %ENV:TRANSLATION_GOOGLE_KEY%
+            push_command                        python %ENV:TMS_PATH%/translation_service/src/serge_ts_connector.py --mode push_ts --translation_api google --google_key_path %ENV:TRANSLATION_GOOGLE_KEY%
         }
     }
 

--- a/translation_service/src/serge_ts_connector.py
+++ b/translation_service/src/serge_ts_connector.py
@@ -11,12 +11,6 @@ root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
 utils_path = f'{root_path}/common/src'
 sys.path.append(utils_path)
 
-# Paths for each directory based on environment variables
-SERGE_TS = os.environ['SERGE_TS']
-TS_SERGE_COPY = os.environ['TS_SERGE_COPY']
-TS_INBOX = os.environ['TS_INBOX']
-TS_OUTBOX = os.environ['TS_OUTBOX']
-
 
 def serge_push_ts(serge_ts, ts_serge_copy, ts_inbox, ts_outbox, translation_api, google_key_path):
     """Handles the Serge push_ts command. Copies .po files from serge_ts that are new/updated
@@ -127,24 +121,6 @@ def serge_pull_ts(serge_ts, ts_outbox):
     shutil.rmtree(ts_outbox)
 
 
-# def localize(ts_inbox, ts_outbox, translation_api, google_key_path):
-#     """Localizes all the language subdirs in the ts_inbox and writes to the ts_outbox.
-#
-#         Args:
-#             ts_inbox: The path to the inbox dir with language subdirs and files that need to be localized.
-#             ts_outbox: The path to the outbox dir where to write localized language subdirs and files.
-#             translation_api: Translation API to use ("google" for Google Translate,
-#                             "caps" for capitalization (default)).
-#             google_key_path: Path for the Google Service Account JSON keyfile (not required if not using this API).
-#     """
-#
-#     # Localize the project and its po files
-#     localize_project(ts_inbox, ts_outbox, translation_api, google_key_path)
-#
-#     # Remove all contents from inbox once processed (localized)
-#     shutil.rmtree(ts_inbox)
-
-
 def validate_args(mode, serge_dir):
     """Validates the arguments for this program. Exits with message if any invalid args.
 
@@ -174,9 +150,16 @@ class InvalidArgumentError(Exception):
         self.message = message
 
 
+# TODO: Future: Add ability to have project subdirectory structure (possibly via Serge config, possibly this program)
 def main():
     """Program that connects Serge with a translation service, handling Serge push-ts and pull-ts."""
-    # TODO: Future: Add ability to have project subdirectory structure (possibly via Serge config, possibly here)
+
+    # Paths for each directory based on environment variables
+    SERGE_TS = os.environ['SERGE_TS']
+    TS_SERGE_COPY = os.environ['TS_SERGE_COPY']
+    TS_INBOX = os.environ['TS_INBOX']
+    TS_OUTBOX = os.environ['TS_OUTBOX']
+
     parser = argparse.ArgumentParser(description='Handles push-ts and pull-ts for Serge.')
 
     parser.add_argument("--mode", help="mode is either push_ts or pull_ts", required=True)

--- a/translation_service/src/serge_ts_connector.py
+++ b/translation_service/src/serge_ts_connector.py
@@ -10,41 +10,36 @@ from project_localizer import localize_project
 root_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))
 utils_path = f'{root_path}/common/src'
 sys.path.append(utils_path)
-from utils import git_push
 
-# TODO: Change to use separate tms-data repo for data (& add to config.serge)
-SERGE_TRANSLATION_DIR = '/var/tms/serge/data/ts'
-TS_SERGE_PO_DIR = '/var/tms/shared_directory/po_files/serge_po'
-TS_INBOX = '/var/tms/shared_directory/po_files/inbox'
-TS_OUTBOX = '/var/tms/shared_directory/po_files/outbox'
-
-# TODO: For each step of the sync (copy_serge_po_files, localize, copy_outbox_to_serge),
-#   add git pull at the beginning of the step and git push at the end of the step
-# ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../..'))  # TODO: Change to tms-data
-# PROJECT_ROOT_GIT_PATH = f'{ROOT_PATH}/.git'
-# # Pull any git repo changes
-# git_pull(PROJECT_ROOT_GIT_PATH)
-# # Push the git repo changes
-# git_push(PROJECT_ROOT_GIT_PATH, commit_message="Update .po files in shared repository")
+# Paths for each directory based on environment variables
+SERGE_TS = os.environ['SERGE_TS']
+TS_SERGE_COPY = os.environ['TS_SERGE_COPY']
+TS_INBOX = os.environ['TS_INBOX']
+TS_OUTBOX = os.environ['TS_OUTBOX']
 
 
-def copy_serge_po_files(serge_translation_dir, ts_serge_po_dir, ts_inbox):
-    """Copies files from serge_translation_dir that are new/updated (compares to those in the ts_serge_po_dir)
-        to both ts_serge_po_dir (local copy) and ts_inbox (files to process).
+def serge_push_ts(serge_ts, ts_serge_copy, ts_inbox, ts_outbox, translation_api, google_key_path):
+    """Handles the Serge push_ts command. Copies .po files from serge_ts that are new/updated
+        (compares to those in the ts_serge_copy) to both ts_serge_copy (local copy) and ts_inbox (files to process).
+        Also localizes all the language subdirs in the ts_inbox and writes to the ts_outbox.
         NOTE: This will also copy over any files that have been previously localized and pushed to Serge since
-            Serge will change the line breaks in any localized msgstr, requiring update on the part of ts_serge_po_dir,
+            Serge will change the line breaks in any localized msgstr, requiring update on the part of ts_serge_copy,
             causing the files to go through the localization process once more, although none of the strings will be
             retranslated (simply parsed and then rewritten to the ts_outbox).
 
         Args:
-            serge_translation_dir: The path to the directory where Serge has the .po files that need translation.
-            ts_serge_po_dir: The path to the translation service's directory of local copies of serge .po files
+            serge_ts: The path to the directory where Serge has the .po files that need translation.
+            ts_serge_copy: The path to the translation service's directory of local copies of serge .po files
                 to add any new/updated files to.
             ts_inbox: The path to the translation service inbox (files to process) to copy the files to.
+            ts_outbox: The path to the outbox dir where to write localized language subdirs and files.
+            translation_api: Translation API to use ("google" for Google Translate,
+                            "caps" for capitalization (default)).
+            google_key_path: Path for the Google Service Account JSON keyfile (not required if not using this API).
     """
     # Get a list of all the subdirs in serge_translation_dir
-    subdirs = [subdir for subdir in os.listdir(serge_translation_dir)
-               if os.path.isdir(os.path.join(serge_translation_dir, subdir))]
+    subdirs = [subdir for subdir in os.listdir(serge_ts)
+               if os.path.isdir(os.path.join(serge_ts, subdir))]
 
     # TODO: Future: See if there is a better way to handle this (git diff?)
     # TODO: Future: Think about how to handle orphaned files (no longer exist on Serge side)
@@ -52,10 +47,10 @@ def copy_serge_po_files(serge_translation_dir, ts_serge_po_dir, ts_inbox):
     # and copy any new/updated files as well
     for subdir in subdirs:
 
-        subdir_path = os.path.join(serge_translation_dir, subdir)
+        subdir_path = os.path.join(serge_ts, subdir)
 
         # Create the subdir if it doesn't already exist in ts_serge_po_dir and ts_inbox
-        ts_serge_subdir_path = os.path.join(ts_serge_po_dir, subdir)
+        ts_serge_subdir_path = os.path.join(ts_serge_copy, subdir)
         ts_inbox_subdir_path = os.path.join(ts_inbox, subdir)
         if not os.path.exists(ts_serge_subdir_path):
             os.makedirs(ts_serge_subdir_path)
@@ -87,12 +82,18 @@ def copy_serge_po_files(serge_translation_dir, ts_serge_po_dir, ts_inbox):
                     shutil.copy2(serge_file_path, ts_serge_file_path)
                     shutil.copy2(serge_file_path, ts_inbox_file_path)
 
+    # Localize the project and its po files
+    localize_project(ts_inbox, ts_outbox, translation_api, google_key_path)
 
-def copy_outbox_to_serge(serge_translation_dir, ts_outbox):
-    """Copies the localized .po files from ts_outbox into the serge_translation_dir.
+    # Remove all contents from inbox once processed (localized)
+    shutil.rmtree(ts_inbox)
+
+
+def serge_pull_ts(serge_ts, ts_outbox):
+    """Handles the Serge push_ts command. Copies the localized .po files from ts_outbox into serge_ts.
 
         Args:
-            serge_translation_dir: The path to the directory where Serge has the .po files that need updating.
+            serge_ts: The path to the directory where Serge has the .po files that need updating.
             ts_outbox: The path to the translation service outbox where the localized .po files are.
     """
 
@@ -106,7 +107,7 @@ def copy_outbox_to_serge(serge_translation_dir, ts_outbox):
         ts_outbox_subdir_path = os.path.join(ts_outbox, subdir)
 
         # Get the subdir paths for where to copy to in serge
-        serge_subdir_path = os.path.join(serge_translation_dir, subdir)
+        serge_subdir_path = os.path.join(serge_ts, subdir)
 
         # Get a list of all files in this subdir
         # Note: Assumes there are no further nested subdirectories
@@ -122,28 +123,26 @@ def copy_outbox_to_serge(serge_translation_dir, ts_outbox):
             # Copy/Overwrite
             shutil.copy2(ts_outbox_file_path, serge_file_path)
 
-    # TODO: Change this so that it is recognized by git (once git pull/push enabled)
     # Remove all contents from outbox once processed (copied to Serge)
     shutil.rmtree(ts_outbox)
 
 
-def localize(ts_inbox, ts_outbox, translation_api, google_key_path):
-    """Localizes all the language subdirs in the ts_inbox and writes to the ts_outbox.
-
-        Args:
-            ts_inbox: The path to the inbox dir with language subdirs and files that need to be localized.
-            ts_outbox: The path to the outbox dir where to write localized language subdirs and files.
-            translation_api: Translation API to use ("google" for Google Translate,
-                            "caps" for capitalization (default)).
-            google_key_path: Path for the Google Service Account JSON keyfile (not required if not using this API).
-    """
-
-    # Localize the project and its po files
-    localize_project(ts_inbox, ts_outbox, translation_api, google_key_path)
-
-    # TODO: Change this so that it is recognized by git (once git pull/push enabled)
-    # Remove all contents from inbox once processed (localized)
-    shutil.rmtree(ts_inbox)
+# def localize(ts_inbox, ts_outbox, translation_api, google_key_path):
+#     """Localizes all the language subdirs in the ts_inbox and writes to the ts_outbox.
+#
+#         Args:
+#             ts_inbox: The path to the inbox dir with language subdirs and files that need to be localized.
+#             ts_outbox: The path to the outbox dir where to write localized language subdirs and files.
+#             translation_api: Translation API to use ("google" for Google Translate,
+#                             "caps" for capitalization (default)).
+#             google_key_path: Path for the Google Service Account JSON keyfile (not required if not using this API).
+#     """
+#
+#     # Localize the project and its po files
+#     localize_project(ts_inbox, ts_outbox, translation_api, google_key_path)
+#
+#     # Remove all contents from inbox once processed (localized)
+#     shutil.rmtree(ts_inbox)
 
 
 def validate_args(mode, serge_dir):
@@ -177,14 +176,14 @@ class InvalidArgumentError(Exception):
 
 def main():
     """Program that connects Serge with a translation service, handling Serge push-ts and pull-ts."""
-    # TODO: Future: Add ability to have project subdirectory structure
+    # TODO: Future: Add ability to have project subdirectory structure (possibly via Serge config, possibly here)
     parser = argparse.ArgumentParser(description='Handles push-ts and pull-ts for Serge.')
 
     parser.add_argument("--mode", help="mode is either push_ts or pull_ts", required=True)
     parser.add_argument("--serge_dir", help="filepath for serge/ts/ directory with .po files. Default={}".format(
-        SERGE_TRANSLATION_DIR), default=SERGE_TRANSLATION_DIR)
+        SERGE_TS), default=SERGE_TS)
     parser.add_argument("--ts_serge_dir", help="filepath for translation_service copy of serge/ts/. Default={}".format(
-        TS_SERGE_PO_DIR), default=TS_SERGE_PO_DIR)
+        TS_SERGE_COPY), default=TS_SERGE_COPY)
     parser.add_argument("--ts_inbox", help="filepath for translation_service inbox directory. Default={}".format(
         TS_INBOX), default=TS_INBOX)
     parser.add_argument("--ts_outbox", help="filepath for translation_service outbox directory. Default={}".format(
@@ -218,17 +217,15 @@ def main():
     if not os.path.exists(args.ts_outbox):
         os.makedirs(args.ts_outbox)
 
-
-    # TODO: Future: Handle push_ts being before localization cycle is complete,
-    #   potentially via multiple time-stamped inboxes (or replace with queues)
+    # TODO: Future: Handle the case where push_ts is being called before the localization cycle is complete;
+    #   potentially solve via multiple time-stamped inboxes (or replace with queues)
 
     if args.mode == 'push_ts':
-        copy_serge_po_files(serge_translation_dir=args.serge_dir, ts_serge_po_dir=args.ts_serge_dir,
-                            ts_inbox=args.ts_inbox)
-        localize(ts_inbox=args.ts_inbox, ts_outbox=args.ts_outbox, translation_api=args.translation_api,
-                 google_key_path=args.google_key_path)
+        serge_push_ts(serge_ts=args.serge_dir, ts_serge_copy=args.ts_serge_dir,
+                      ts_inbox=args.ts_inbox, ts_outbox=args.ts_outbox,
+                      translation_api=args.translation_api, google_key_path=args.google_key_path)
     else:
-        copy_outbox_to_serge(serge_translation_dir=args.serge_dir, ts_outbox=args.ts_outbox)
+        serge_pull_ts(serge_ts=args.serge_dir, ts_outbox=args.ts_outbox)
 
 
 if __name__ == "__main__":

--- a/translation_service/src/serge_ts_connector.py
+++ b/translation_service/src/serge_ts_connector.py
@@ -84,7 +84,7 @@ def serge_push_ts(serge_ts, ts_serge_copy, ts_inbox, ts_outbox, translation_api,
 
 
 def serge_pull_ts(serge_ts, ts_outbox):
-    """Handles the Serge push_ts command. Copies the localized .po files from ts_outbox into serge_ts.
+    """Handles the Serge pull_ts command. Copies the localized .po files from ts_outbox into serge_ts.
 
         Args:
             serge_ts: The path to the directory where Serge has the .po files that need updating.

--- a/translation_service/test/test_po_file.py
+++ b/translation_service/test/test_po_file.py
@@ -151,6 +151,7 @@ class TestPoFile(unittest.TestCase):
             expected returns: (None)
 
         """
+        # ------------ Setup -------------
 
         # Create a translator object that does capitalization
         translator = TranslatorFactory.get_translator(translation_api='caps')
@@ -165,6 +166,8 @@ class TestPoFile(unittest.TestCase):
             elem = MsgElement(GOLDEN_PO_MSGHEADER_LISTS[i], GOLDEN_PO_MSGID_LISTS[i], GOLDEN_PO_MSGSTR_LISTS[i])
             msg_elements.append(elem)
         po.msg_elements = msg_elements
+
+        # ------------ Run translate_po_file -------------
 
         po.translate_po_file(TARGET_LANGUAGE_ISO, translator)
 
@@ -187,6 +190,7 @@ class TestPoFile(unittest.TestCase):
             expected returns: (None)
 
         """
+        # ------------ Setup -------------
 
         # Initialize PoFile object
         po = PoFile(self.in_example_filepath)
@@ -205,6 +209,8 @@ class TestPoFile(unittest.TestCase):
 
         # Get path for where to write out file
         out_example_filepath = os.path.join(self.temp_out_dir, EXAMPLE_FILE)
+
+        # ------------ Run write_localized_po_file -------------
 
         # Call write_localized_po_file to write to the out_example_filepath
         po.write_localized_po_file(out_example_filepath)

--- a/translation_service/test/test_project_localizer.py
+++ b/translation_service/test/test_project_localizer.py
@@ -31,11 +31,17 @@ class TestPoLocalizer(unittest.TestCase):
         shutil.rmtree(cls.temp_root_dir)
 
     def test_localize_project(self):
+        """ Test for localize_project()
+
+            setup: input_dir must hold language subdirs with .po files inside.
+
+            file modifications: localization subdirs created in output_dir
+
+            expected args: input_dir, output_dir, translation_api, google_key_path
+            expected returns: (None)
         """
-        localize_project
-            expected in: input_dir, output_dir, translation_api, google_key_path
-            expected out: localization subdirs created in output_dir
-        """
+        # ------------ Setup -------------
+
         # Make temporary in/out directories to hold the test resources in
         temp_in_dir = os.path.join(self.temp_root_dir, 'in')
         temp_out_dir = os.path.join(self.temp_root_dir, 'out')
@@ -60,6 +66,8 @@ class TestPoLocalizer(unittest.TestCase):
             lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
             shutil.copyfile(golden_in_filepath, lang_subdir_example_path)
 
+        # ------------ Run localize_project -------------
+
         # Call localize_project with the test input and output directories
         project_localizer.localize_project(temp_in_dir, temp_out_dir, translation_api='caps')
 
@@ -69,11 +77,19 @@ class TestPoLocalizer(unittest.TestCase):
             self.assertTrue(os.path.exists(lang_subdir))
 
     def test_localize_po_file(self):
+        """ Test for localize_po_file()
+
+            setup:
+                - in_path must hold a po_file inside
+                - translator must be a CapsTranslator object
+
+            file modifications: localized po_file written to out_path
+
+            expected args: in_path, out_path, po_file (golden), target_lang_iso, translator
+            expected returns: (None)
         """
-        localize_po_file
-            expected in: in_path, out_path, po_file (golden), target_lang_iso, translator
-            expected out: localized po_file written to out_path
-        """
+        # ------------ Setup -------------
+
         # Make temporary in/out directories to hold the test resources in
         temp_in_dir = os.path.join(self.temp_root_dir, 'in')
         temp_out_dir = os.path.join(self.temp_root_dir, 'out')
@@ -97,6 +113,8 @@ class TestPoLocalizer(unittest.TestCase):
         # Create a translator object that does capitalization
         translator = TranslatorFactory.get_translator(translation_api='caps')
 
+        # ------------ Run po_localizer -------------
+
         # Call po_localizer
         project_localizer.localize_po_file(temp_in_dir, temp_out_dir, EXAMPLE_FILE, lang, translator)
 
@@ -107,11 +125,16 @@ class TestPoLocalizer(unittest.TestCase):
         self.assertTrue(os.path.exists(out_example_filepath))
 
     def test_create_output_localized_subdir(self):
+        """ Test for create_output_localized_subdir()
+
+            setup: output_dir must exist.
+
+            file modifications: subdir for target_lang_iso created in output_dir
+
+            expected args: output_dir, target_lang_iso
+            expected returns: (None)
         """
-        create_output_localized_subdir
-            expected in: output_dir, target_lang_iso
-            expected out: subdir for target_lang_iso created in output_dir
-        """
+        # ------------ Setup -------------
 
         # Make temporary out directory
         temp_out_dir = os.path.join(self.temp_root_dir, 'out')
@@ -122,6 +145,8 @@ class TestPoLocalizer(unittest.TestCase):
         # Language subdir and path for testing
         lang = TARGET_LANGUAGE_ISO_LIST[0]
         lang_subdir = os.path.join(temp_out_dir, lang)
+
+        # ------------ run create_output_locacalized_subdir -------------
 
         # Call create_output_localized_subdir
         project_localizer.create_output_localized_subdir(temp_out_dir, lang)

--- a/translation_service/test/test_serge_ts_connector.py
+++ b/translation_service/test/test_serge_ts_connector.py
@@ -1,3 +1,4 @@
+import filecmp
 import tempfile
 import unittest
 import sys
@@ -5,7 +6,6 @@ import os
 import shutil
 sys.path.append('src')
 import serge_ts_connector
-
 
 EXAMPLE_FILE = 'example.po'
 GOLDEN_EXAMPLE_IN = 'golden_in.po'
@@ -31,17 +31,144 @@ class TestSergeTsConnector(unittest.TestCase):
         # Remove temporary root directory and its subdirectories & files
         shutil.rmtree(cls.temp_root_dir)
 
-    def test_copy_serge_po_files(self):
-        """TODO: stub test for copy_serge_po_files function."""
-        pass
+    def test_serge_push_ts(self):
+        """ Test for serge_push_ts()
 
-    def test_copy_outbox_to_serge(self):
-        """TODO: stub test for copy_outbox_to_serge function."""
-        pass
+            setup: serge_ts directory must hold language subdirs with .po files inside.
 
-    def test_localize(self):
-        """TODO: stub test for localize function."""
-        pass
+            file modifications:
+                - Copies of subdirs and .po files from serge_ts will be added to ts_serge_copy.
+                - A localized version of those subdirs & .po files will be added to the ts_outbox.
+                - ts_inbox will be created and deleted.
+
+            expected args: serge_ts, ts_serge_copy, ts_inbox, ts_outbox, translation_api, google_key_path
+            expected returns: (None)
+        """
+        # ------------ Setup -------------
+
+        # Make temporary directories to hold the test resources in
+        temp_serge_ts = os.path.join(self.temp_root_dir, 'serge_ts')
+        temp_ts_serge_copy = os.path.join(self.temp_root_dir, 'ts_serge_copy')
+        temp_ts_inbox = os.path.join(self.temp_root_dir, 'ts_inbox')
+        temp_ts_outbox = os.path.join(self.temp_root_dir, 'ts_outbox')
+
+        if not os.path.exists(temp_serge_ts):
+            os.makedirs(temp_serge_ts)
+        if not os.path.exists(temp_ts_serge_copy):
+            os.makedirs(temp_ts_serge_copy)
+        if not os.path.exists(temp_ts_inbox):
+            os.makedirs(temp_ts_inbox)
+        if not os.path.exists(temp_ts_outbox):
+            os.makedirs(temp_ts_outbox)
+
+        # Get the path for the golden in example file
+        golden_in_filepath = os.path.join(RESOURCES_DIR, GOLDEN_EXAMPLE_IN)
+
+        # Create subdirectories in temp_serge_ts for each target languages
+        # and add a copy of the golden in example file in each
+        for lang in TARGET_LANGUAGE_ISO_LIST:
+            lang_subdir = os.path.join(temp_serge_ts, lang)
+            if not os.path.exists(lang_subdir):
+                os.makedirs(lang_subdir)
+
+            # Copy the golden in example file into the lang_subdir
+            lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
+            shutil.copyfile(golden_in_filepath, lang_subdir_example_path)
+
+        # Get the path for the golden out example file
+        golden_out_filepath = os.path.join(RESOURCES_DIR, GOLDEN_EXAMPLE_OUT)
+
+        # ------------ Run serge_push_ts -------------
+
+        serge_ts_connector.serge_push_ts(temp_serge_ts, temp_ts_serge_copy, temp_ts_inbox, temp_ts_outbox,
+                                         translation_api='caps', google_key_path=None)
+
+        # TEST: Check that the temp_ts_serge_copy example files match the golden in files
+        for lang in TARGET_LANGUAGE_ISO_LIST:
+            lang_subdir = os.path.join(temp_ts_serge_copy, lang)
+
+            # Get the example file path
+            lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
+
+            # Use checksum to ensure the file matches the golden in file
+            self.assertTrue(filecmp.cmp(lang_subdir_example_path, golden_in_filepath))
+
+        # TEST: Check that the temp_ts_outbox example files match the golden out files
+        for lang in TARGET_LANGUAGE_ISO_LIST:
+            lang_subdir = os.path.join(temp_ts_outbox, lang)
+
+            # Get the example file path
+            lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
+
+            # Use checksum to ensure the file matches the golden out file
+            self.assertTrue(filecmp.cmp(lang_subdir_example_path, golden_out_filepath))
+
+    def test_serge_pull_ts(self):
+        """ Test for serge_pull_ts()
+
+            setup:
+                - serge_ts directory must hold language subdirs with .po files inside.
+                - ts_outbox must hold any localized versions of the .po files in their respective subdirs.
+
+            file modifications:
+                - Copies of subdirs and .po files from ts_outbox will be added/overwritten to serge_ts.
+                - Outbox will be deleted.
+
+            expected args: serge_ts, ts_outbox
+            expected returns: (None)
+        """
+        # ------------ Setup -------------
+
+        # Make temporary directories to hold the test resources in
+        temp_serge_ts = os.path.join(self.temp_root_dir, 'serge_ts')
+        temp_ts_outbox = os.path.join(self.temp_root_dir, 'ts_outbox')
+
+        if not os.path.exists(temp_serge_ts):
+            os.makedirs(temp_serge_ts)
+        if not os.path.exists(temp_ts_outbox):
+            os.makedirs(temp_ts_outbox)
+
+        # Get the path for the golden in example file
+        golden_in_filepath = os.path.join(RESOURCES_DIR, GOLDEN_EXAMPLE_IN)
+
+        # Create subdirectories in temp_serge_ts for each target languages
+        # and add a copy of the golden in example file in each
+        for lang in TARGET_LANGUAGE_ISO_LIST:
+            lang_subdir = os.path.join(temp_serge_ts, lang)
+            if not os.path.exists(lang_subdir):
+                os.makedirs(lang_subdir)
+
+            # Copy the golden in example file into the lang_subdir
+            lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
+            shutil.copyfile(golden_in_filepath, lang_subdir_example_path)
+
+        # Get the path for the golden out example file
+        golden_out_filepath = os.path.join(RESOURCES_DIR, GOLDEN_EXAMPLE_OUT)
+
+        # Create subdirectories in ts_outbox for each target languages
+        # and add a copy of the golden out example file in each
+        for lang in TARGET_LANGUAGE_ISO_LIST:
+            lang_subdir = os.path.join(temp_ts_outbox, lang)
+            if not os.path.exists(lang_subdir):
+                os.makedirs(lang_subdir)
+
+            # Copy the golden out example file into the lang_subdir
+            lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
+            shutil.copyfile(golden_out_filepath, lang_subdir_example_path)
+
+        # ------------ Run serge_pull_ts -------------
+
+        serge_ts_connector.serge_pull_ts(temp_serge_ts, temp_ts_outbox)
+
+        # TEST: Check that the temp_serge_ts example files have been overwritten with the golden out file
+        for lang in TARGET_LANGUAGE_ISO_LIST:
+            lang_subdir = os.path.join(temp_serge_ts, lang)
+
+            # Get the example file path
+            lang_subdir_example_path = os.path.join(lang_subdir, EXAMPLE_FILE)
+
+            # Use checksum to ensure the file matches the golden out file
+            self.assertTrue(filecmp.cmp(lang_subdir_example_path, golden_out_filepath))
 
     def test_validate_args_invalid_dir(self):
         """


### PR DESCRIPTION
This adds unittests for `test_serge_ts_connector.py` and cleans up the unittests for other .py files slightly.

This also cleans up the code in `serge_ts_connector.py`:
- Uses environment variables for paths as a default 
- Removes code related to `git_push` since Serge is already handling this for `translation_service`.
- Renames & combines methods to match the naming scheme of Serge itself

It also cleans up the Serge configs:
- Removes explicit args for the paths in the serge configs (since now handled by grabbing the env paths in the program itself)

