### PR TITLE
Adds inner HTML parsing to the Serge json parser

### DIFF
--- a/serge/configs/base_config.serge
+++ b/serge/configs/base_config.serge
@@ -181,15 +181,29 @@ common-settings
             # (STRING) Parser class name.
             # See Serge/Engine/Plugin/parse_*.pm files
             plugin                  parse_json
-
             # [OPTIONAL] Plugin data. Each plugin may have specific parameters
             # inside the `data` block. See the documentation for each specific
             # plugin for more information.
             data
             {
                 path_matches \/(about|title|description|content|rendered)$
-        #param1             value1
-                #param2             value2
+                path_html                        \/rendered$
+
+                html_parser
+                {
+                    plugin                      parse_php_xhtml
+
+                    data
+                    {
+                        expand_entities         YES
+
+                        # TODO: Once Serge 1.5 is released, add any additional
+                        # HTML tags that should be parsed to include_tags,
+                        # such as <a>  (below)
+                        
+                        # include_tags            a
+                    }
+                }
             }
         }
 


### PR DESCRIPTION
Note: The current version of Serge (1.4) does not allow adding additional HTML tags to be parsed beyond the default ones (https://serge.io/docs/plugins/parser/parse_php_xhtml/). This means that certain tags (such as `<a>`) that are not currently supported cannot be added and will be included in the strings to translate.

Once the next version of Serge (1.5) is released, these can be added in the Serge config as `include_tags` within the `html_parser`.