### PR TITLE
infra compatibility - removes while loop when running import-google script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,4 @@ tmp/
 .env.template
 docs/
 docker-compose.yml
+secrets/*

--- a/import_export/import-google-docs.py
+++ b/import_export/import-google-docs.py
@@ -148,5 +148,14 @@ def main():
         run()
         sleep(10)
 
+def new_main():
+    run()
+
 if __name__ == "__main__":
-    main()
+    """
+    commenting the original main out because
+    it is not compatible with our cron process.
+    leaving it in because we need to revisit whether this is the best approach.
+    """
+    # main()
+    new_main()


### PR DESCRIPTION
Currently we're leveraging cron to run the program every minute. But the built-in `while` loop is not compatible with that.