### PR TITLE
infra - various fixes that ensure we can run serge and google import/export reliably

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -4,3 +4,5 @@ tmp/
 .env.template
 docs/
 docker-compose.yml
+drive_config.yaml
+drive_config.yaml.template

--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,6 @@ docs/
 docker-compose.yml
 drive_config.yaml
 drive_config.yaml.template
+secrets/*
+serge/db/*
+serge/ts/*

--- a/.env.template
+++ b/.env.template
@@ -14,3 +14,4 @@ WP_IMPORT_PASSWORD='your-wpengine-password'
 WP_EXPORT_URL=https://some-wp-site.wpengine.com
 WP_EXPORT_USER=your-wpengine-export-username
 WP_EXPORT_PASSWORD=your-wp-engine-export-password
+GOOGLE_DRIVE_CONFIG=/var/tms/drive_config.yaml

--- a/drive_config.yaml.template
+++ b/drive_config.yaml.template
@@ -1,0 +1,7 @@
+# This file defines which folders you want Google Drive import/export serivce
+# to import files from and export translated files back.
+language_folders:
+  en:
+    id-of-google-drive-en-folder
+  es:
+    id-of-google-drive-es-folder

--- a/import_export/export-google-docs.py
+++ b/import_export/export-google-docs.py
@@ -54,7 +54,7 @@ def translate_doc(service_docs, doc_id, msgid_text, msgid_str):
     return response
 
 def main():
-    root_path = '/var/tms/serge/ts'
+    root_path = os.environ.get('TS_OUTBOX')
     translation_mapping = None
     with open(os.environ.get('GOOGLE_DRIVE_CONFIG')) as f:
         translation_mapping = yaml.load(f)
@@ -125,7 +125,8 @@ def main():
                             msgid_str = id_str_mapping[msgid_text]
                             print(f"replacing in doc {target_doc_id} {msgid_text} with {msgid_str}")
                             response_replace = translate_doc(service_docs, target_doc_id, msgid_text, msgid_str)
-                    except:
+                    except Exception as error:
+                        print(f"Error occurred while adding translated files back to language folder. {error}")
                         pass
 if __name__ == "__main__":
     main()

--- a/import_export/google_doc_utils.py
+++ b/import_export/google_doc_utils.py
@@ -39,7 +39,8 @@ def generate_secrets(scope):
         if creds and creds.expired and creds.refresh_token:
             creds.refresh(Request())
         else:
-            flow = client.flow_from_clientsecrets(credentials_path, scope)
+            scope_to_send = SCOPE_READ_DRIVE if scope == 'drive' else SCOPE_READ_DOCS
+            flow = client.flow_from_clientsecrets(credentials_path, scope=scope_to_send)
             store = file.Storage(raw_token_path)
             creds = tools.run_flow(flow, store)
         # Save the credentials for the next run

--- a/import_export/import-google-docs.py
+++ b/import_export/import-google-docs.py
@@ -20,7 +20,7 @@ import utils
 
 SOURCE_PATH = 'source_files/en'
 GIT_BRANCH = os.environ.get('TMS_DATA_BRANCH_NAME')
-ROOT_PATH = os.path.abspath(os.path.join(os.path.dirname( __file__ ), '../../tms-data'))
+ROOT_PATH = os.environ.get('TMS_DATA_PATH')
 GIT_REPO_PATH = f'{ROOT_PATH}/.git'
 COMMIT_MESSAGE = 'Update shared repository'
 

--- a/serge/configs/caps_config.serge
+++ b/serge/configs/caps_config.serge
@@ -20,6 +20,8 @@ jobs
     {
         @inherit                   base_config.serge#common-settings/job
 
+        db_source                   DBI:SQLite:dbname=../db/capitalizedTranslations.db3
+
         # Destination languages can be changed to a space separated list (ex. es fr ru)
         # Supported languages include: es zh ru bn ht ko ar fr ur pl
         destination_languages       es

--- a/serge/configs/google_config.serge
+++ b/serge/configs/google_config.serge
@@ -26,6 +26,8 @@ jobs
     {
         @inherit                   base_config.serge#common-settings/job
 
+        db_source                   DBI:SQLite:dbname=../db/googleTranslations.db3
+
         # Destination languages can be changed to a space separated list (ex. es fr ru)
         # Supported languages include: es zh ru bn ht ko ar fr ur pl
         destination_languages       es


### PR DESCRIPTION
# Why?
- Most of these were needed in order for me to get Google Drive import/export process to work.
- Added documentation/templates for new environment variable.
- Separated out the Serge translation memory databases for google and caps-config as we don't want these to get cluttered and give wrong translations.