### PR TITLE
fixes un-ending loop in word-press import code. adds helpful success/error messages.

### DIFF
--- a/common/src/utils.py
+++ b/common/src/utils.py
@@ -27,7 +27,7 @@ def git_push(git_repo_path, commit_message="Update data repository", enable_push
 
     t = repo.head.commit.tree
     repo.index.add(["source_files/en"])
-    if repo.git.diff(t):
+    if repo.git.diff("source_files/en"):
         repo.index.commit(commit_message)
         if enable_push:
             log.write(PUSHING_MESSAGE)

--- a/import_export/export-wordpress.py
+++ b/import_export/export-wordpress.py
@@ -79,8 +79,13 @@ def update_wordpress(id, language, title, content, excerpt=""):
   user = os.environ.get('WP_EXPORT_USER')
   password = os.environ.get('WP_EXPORT_PASSWORD')
 
-  # response = requests.post(url, headers=header, json=message)
   response = requests.post(url, headers={"Content-Type": "application/json", 'User-Agent': ""}, auth=HTTPBasicAuth(user, password), json=message)
+
+  if not response.status_code == 201:
+    raise Exception(f"Update wordpress failed- {response.json()}")
+
+  print(f'Successfully updated post with ID: {id} Title: {title} Language: {language}')
+
   return {"status": "success"}
 
 

--- a/import_export/import-wordpress.py
+++ b/import_export/import-wordpress.py
@@ -41,6 +41,17 @@ def get_posts():
 
 def do_work():
     for post in get_posts():
+        """
+        Example wp link: 'https://ctoassetsstg.wpengine.com/es/2020/10/09/aditya-another-test-post/'
+
+        If there is a locale specified like `es` in the above link, then we do not want to import it as it is an already translated post.
+        Note: This logic does not support a non-english source language.
+        """
+        split_link = post['link'].split('/')
+        if len(split_link[3]) == 2:
+            print(f"Will not import translated post - ID: {post['id']} Title: {post['title']} Link: {post['link']}")
+            continue
+
         write_post(post)
     utils.git_push(utils.PROJECT_ROOT_GIT_PATH, commit_message="Update shared repository: wordpress", enable_push=True)
 
@@ -49,12 +60,20 @@ api = Api(app)
 
 class WordpressUpdateListener(Resource):
     def get(self):
-        do_work()
-        return "Get"
+        try:
+            do_work()
+            return {"success": True}
+        except Exception as error:
+            message = f"Something went wrong: {error}"
+            return {"success": False, "error_message": message}
 
     def post(self):
-        do_work()
-        return "Post"
+        try:
+            do_work()
+            return {"success": True}
+        except Exception as error:
+            message = f"Something went wrong: {error}"
+            return {"success": False, "error_message": message}
 
 api.add_resource(WordpressUpdateListener, "/wp-updates")
 


### PR DESCRIPTION
## Why?
- We're creating translations for pre-translated wordpress posts. This is causing things to go in an unending loop.