### PR TITLE
Remove unused script files and methods

### DIFF
--- a/import_export/export-google-docs.py
+++ b/import_export/export-google-docs.py
@@ -23,18 +23,6 @@ COMMIT_MESSAGE = 'Update shared repository'
 UPDATE_URL_ROOT = 'https://docs.googleapis.com/v1/documents'
 
 
-def read_paragraph_element(element):
-    """Returns the text in the given ParagraphElement.
-
-        Args:
-            element: a ParagraphElement from a Google Doc.
-    """
-    text_run = element.get('textRun')
-    if not text_run:
-        return ''
-    return text_run.get('content')
-
-
 def translate_doc(service_docs, doc_id, msgid_text, msgid_str):
     payload = {
       "requests": [

--- a/import_export/import-google-docs.py
+++ b/import_export/import-google-docs.py
@@ -23,46 +23,6 @@ GIT_BRANCH = os.environ.get('TMS_DATA_BRANCH_NAME')
 ROOT_PATH = os.environ.get('TMS_DATA_PATH')
 GIT_REPO_PATH = f'{ROOT_PATH}/.git'
 COMMIT_MESSAGE = 'Update shared repository'
-
-
-def read_paragraph_element(element):
-    """Returns the text in the given ParagraphElement.
-
-        Args:
-            element: a ParagraphElement from a Google Doc.
-    """
-    text_run = element.get('textRun')
-    if not text_run:
-        return ''
-    return text_run.get('content')
-
-
-def read_structural_elements(elements):
-    """Recurses through a list of Structural Elements to read a document's text where text may be
-        in nested elements.
-
-        Args:
-            elements: a list of Structural Elements.
-    """
-    text = ''
-    for value in elements:
-        if 'paragraph' in value:
-            elements = value.get('paragraph').get('elements')
-            for elem in elements:
-                text += read_paragraph_element(elem)
-        elif 'table' in value:
-            # The text in table cells are in nested Structural Elements and tables may be
-            # nested.
-            table = value.get('table')
-            for row in table.get('tableRows'):
-                cells = row.get('tableCells')
-                for cell in cells:
-                    text += read_structural_elements(cell.get('content'))
-        elif 'tableOfContents' in value:
-            # The text in the TOC is also in a Structural Element.
-            toc = value.get('tableOfContents')
-            text += read_structural_elements(toc.get('content'))
-    return text
  
 
 def main():

--- a/run_serge.sh
+++ b/run_serge.sh
@@ -1,7 +1,0 @@
-cd /var/tms
-echo "Current Datetime is : $(date)"
-python import_export/import-google-docs.py
-serge sync /var/tms/serge/configs/google_config.serge
-sleep 3
-serge sync /var/tms/serge/configs/google_config.serge
-python import_export/export-google-docs.py

--- a/setup_cron.sh
+++ b/setup_cron.sh
@@ -1,3 +1,0 @@
-{ printenv; echo ''; cat /var/tms/cron.config; echo ""; } > /var/tms/tmpfile && mv /var/tms/tmpfile /var/tms/cron.config
-crontab /var/tms/cron.config
-service cron restart


### PR DESCRIPTION
Based on issue https://github.com/nyc-cto/tms/issues/61.

Removes two scripts to run Serge that are currently not being used to simplify the ways Serge can be run and avoid confusion.

Also removes text parsing functions in the import/export Google doc scripts which were initially researched as a way of parsing Google docs but was eventually decided to not be used.